### PR TITLE
Fixed handling of 12am and 12pm 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run", 
+            "type": "go",
+            "request": "launch", 
+            "mode": "auto", 
+            "console": "integratedTerminal",
+            "program": "cmd/zc/main.go"
+        }
+    ]
+}

--- a/doc/types.md
+++ b/doc/types.md
@@ -85,18 +85,18 @@ All of the following formats can be parsed:
 
 | Input                      | Stack
 |----------------------------|-------------
-| `c 2006-01 dt`             | `Sun Jan 1 2006 0:00:00am -0700 MST`
-| `c 2006-01-02 dt`          | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 2006-032 dt`            | `Wed Feb 1 2006 0:00:00am -0700 MST`
-| `c 1/2 dt`                 | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 1/2/2006 dt`            | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 1/2/06 dt`              | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 'Jan 2 2006' dt`        | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 'Jan 2 06' dt`          | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 'Fri Jan 2 2006' dt`    | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 'Friday Jan 2 2006' dt` | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 'Jan 2' dt`             | `Mon Jan 2 2006 0:00:00am -0700 MST`
-| `c 'Fri, Jan 2' dt`        | `Mon Jan 2 2006 0:00:00am -0700 MST`
+| `c 2006-01 dt`             | `Sun Jan 1 2006 12:00:00am -0700 MST`
+| `c 2006-01-02 dt`          | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 2006-032 dt`            | `Wed Feb 1 2006 12:00:00am -0700 MST`
+| `c 1/2 dt`                 | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 1/2/2006 dt`            | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 1/2/06 dt`              | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 'Jan 2 2006' dt`        | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 'Jan 2 06' dt`          | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 'Fri Jan 2 2006' dt`    | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 'Friday Jan 2 2006' dt` | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 'Jan 2' dt`             | `Mon Jan 2 2006 12:00:00am -0700 MST`
+| `c 'Fri, Jan 2' dt`        | `Mon Jan 2 2006 12:00:00am -0700 MST`
 | `c 15:04:05 dt`            | `Mon Jan 2 2006 3:04:05pm -0700 MST`
 | `c '15:04:05 PDT' dt`      | `Mon Jan 2 2006 3:04:05pm -0700 PDT`
 | `c 15:04 dt`               | `Mon Jan 2 2006 3:04:00pm -0700 MST`

--- a/pkg/ptime/format.go
+++ b/pkg/ptime/format.go
@@ -145,6 +145,9 @@ func formatHour(loc *locale.Locale, format string, t time.Time) string {
 		if h > 12 {
 			h = h - 12
 		}
+		if h == 0 {
+			h = 12
+		}
 		return strconv.Itoa(h)
 	}
 	return badFormat

--- a/pkg/ptime/format_test.go
+++ b/pkg/ptime/format_test.go
@@ -103,7 +103,11 @@ func TestFormatEnUS(t *testing.T) {
 			"[hour]:[minute]:[second] [offset-zone]",
 			"17:30:25 UTC",
 		},
-
+		{
+			"5:30PM",
+			"[hour/12]:[minute][period]",
+			"5:30PM",
+		},
 		{
 			"17:30:25",
 			"[hour/12]:[minute][period]",

--- a/pkg/ptime/time.go
+++ b/pkg/ptime/time.go
@@ -71,8 +71,11 @@ func Time(l *locale.Locale, p Parsed, now time.Time) (time.Time, error) {
 			if !ok {
 				return time.Time{}, fmt.Errorf("invalid period: %v", p.Period)
 			}
-			if num == int(locale.PM) || num == int(locale.Midnight) {
+			if hour != 12 && (num == int(locale.PM) || num == int(locale.Noon)) {
 				hour += 12
+			}
+			if hour == 12 && (num == int(locale.AM) || num == int(locale.Midnight)) {
+				hour = 0
 			}
 		}
 	}

--- a/test/ops/time.md
+++ b/test/ops/time.md
@@ -1,0 +1,7 @@
+# time
+
+## time
+
+    c 12:15p time -- 12:15:00pm -0700 MST
+    c 12:15a time -- 12:15:00am -0700 MST
+


### PR DESCRIPTION
Resolves #3. 

- fixed parsing of 12am and 12pm
- fixed formatting of midnight to 12am
- added a launch configuration for VS code for using the integrated debugger