### PR TITLE
Fix quote prompt, blank quote lines, add end quote to prompt

### DIFF
--- a/pkg/repl/commands.go
+++ b/pkg/repl/commands.go
@@ -62,7 +62,9 @@ func def(r *REPL, s *scan.Scanner) error {
 }
 
 func pop(r *REPL, _ *scan.Scanner) error {
-	r.Calc.Pop()
+	if r.quoteEnd == "" {
+		r.Calc.Pop()
+	}
 	return nil
 }
 

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -176,7 +176,7 @@ func (r *REPL) saveHistory() {
 
 func (r *REPL) getPrompt() string {
 	if r.quoteEnd != "" {
-		return "...>"
+		return fmt.Sprintf("... %s> ", r.quoteEnd)
 	}
 	return zc.ProgName + " > "
 }

--- a/pkg/repl/repl_test.go
+++ b/pkg/repl/repl_test.go
@@ -70,6 +70,25 @@ func TestQuote(t *testing.T) {
 	}
 }
 
+func TestQuoteBlanks(t *testing.T) {
+	ansi.Enabled = false
+	c := calc.New()
+	repl := New(c)
+
+	repl.Eval("quote EOF")
+	repl.Eval("1 2 add")
+	repl.Eval("2 3 sub")
+	repl.Eval("")
+	repl.Eval("")
+	repl.Eval("EOF")
+
+	have := c.Stack()
+	want := []string{"1 2 add", "2 3 sub"}
+	if !reflect.DeepEqual(have, want) {
+		t.Fatalf("\n have: %v \n want: %v", have, want)
+	}
+}
+
 func TestCommonPrefix(t *testing.T) {
 	tests := []struct {
 		common string


### PR DESCRIPTION
Resolves #8. 

- fix quote prompt by placing a space after `>`
- change quote prompt to include the ending token (for example, `... EOF> `)
- fix bug where blank lines in quoted text was popping lines from the stack. Blank lines are a no-op now. 
